### PR TITLE
fix: update makeCreateTransaction issuers type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run Planetmint node
         run: |
           echo Building and starting up docker containers
-          docker-compose -f ./docker-compose.yml up -d
+          docker compose -f ./docker-compose.yml up -d
 
       - name: Install dependencies
         env:

--- a/types/transaction.d.ts
+++ b/types/transaction.d.ts
@@ -239,7 +239,7 @@ export default class Transaction {
     assetData: CID[],
     metadata: CID,
     outputs: TransactionOutput[],
-    ...issuers: string[]
+    issuers: string[]
   ): CreateTransaction<TransactionVersion.V3, CID[]>;
 
   static makeCreateTransactionV2<


### PR DESCRIPTION
## Problem

PR #9 updated the function signature for `makeCreateTransaction` but the types were not updated, so the type is currently out of date and incompatible.

## Solution

This PR updates the type, resolving the issue. 

## Issues Resolved

Resolves #25

## Checklist

- [ ] version number increased
- [ ] CHANGELOG.md updated
- [ ] unit test added
- [ ] documentation updated or added